### PR TITLE
Requires Ruby 2.7+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6 # NOTE: same to TargetRubyVersion in .rubocop.yml
+          ruby-version: 2.7 # NOTE: same to TargetRubyVersion in .rubocop.yml
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop
@@ -40,7 +40,6 @@ jobs:
         ## Due to https://github.com/actions/runner/issues/849,
         ## we have to use quotes for '3.0'
         ruby:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_mode:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
   NewCops: enable
 

--- a/faraday-mashify.gemspec
+++ b/faraday-mashify.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.6', '< 4'
+  spec.required_ruby_version = '>= 2.7', '< 4'
 
   spec.add_runtime_dependency 'faraday', '~> 2.0'
   spec.add_runtime_dependency 'hashie'


### PR DESCRIPTION
I want to RuboCop 1.74 at #21 

But latest RuboCop requires Ruby 2.7+
https://rubygems.org/gems/rubocop/versions/1.74.0

Ruby 2.6 EOL is 2022-04-12 (3 years ago)
https://www.ruby-lang.org/en/downloads/branches/

So I want to drop Ruby 2.6