### PR TITLE
Support Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up Ruby

--- a/faraday-mashify.gemspec
+++ b/faraday-mashify.gemspec
@@ -30,12 +30,11 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 2.7', '< 4'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'hashie'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'


### PR DESCRIPTION
The pull request proposes removing the < 4 upper bound on required_ruby_version in the gemspec. 
With Ruby 4.0 scheduled for release on Christmas Day and a preview already available

Ruby 4.0.0 preview3 Released
https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/

the current constraint prevents gem install faraday‑mashify from working on Ruby 4.0. Dropping the upper bound ensures the gem will install cleanly on Ruby 4.0 and future Ruby versions. The change also removes the development dependency on Bundler because Ruby 4.0 ships with Bundler 4 by default, and it updates the CI matrix to include Ruby 4.0.

[faraday-mashify/Gemfile](https://github.com/sue445/faraday-mashify/blob/6b8f631791ae04b6b835d8c150fb5df4980c63d9/faraday-mashify.gemspec#L38)

