### PR TITLE
Fix Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/OneClassPerFile.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ module EnvCompatibility
   end
 end
 
-module ResponseMiddlewareExampleGroup # rubocop:disable Style/OneClassPerFile
+module ResponseMiddlewareExampleGroup
   def self.included(base)
     base.let(:options) { {} }
     base.let(:headers) { {} }


### PR DESCRIPTION
```
Offenses:

spec/spec_helper.rb:17:39: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/OneClassPerFile.
module ResponseMiddlewareExampleGroup # rubocop:disable Style/OneClassPerFile
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

11 files inspected, 1 offense detected, 1 offense autocorrectable
```

Close #57